### PR TITLE
Restart fix

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>video_stream_spoofing_attack</name>
-  <version>0.0.6</version>
+  <version>0.0.7</version>
   <description>TODO: Package description</description>
   <maintainer email="mehmet.killioglu@unikie.com">mehmet</maintainer>
   <license>TODO: License declaration</license>

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -283,7 +283,7 @@ private:
       gst_buffer_map(buffer, &info, GST_MAP_READ);
 
       if (info.data != NULL) {
-        GstSegment *seg = gst_sample_get_segment (sample);
+        // GstSegment *seg = gst_sample_get_segment (sample);
         int width, height;
         GstStructure * str;
 
@@ -299,7 +299,7 @@ private:
         auto img = std::make_unique<sensor_msgs::msg::Image>();
         // The queue prevents sequential reading. So, the pts misbehaves as the timestamp is not monotonic.
         // So, dts is used for the stamp.
-        
+
         // GstClockTime stamp = buffer->pts;
         GstClockTime pos = buffer->dts;
         // GstClockTime stamp = GST_BUFFER_TIMESTAMP(buffer);

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -190,7 +190,7 @@ private:
    std::string gst_launch;
     if (video_file_.empty()){
 
-      gst_launch = "videotestsrc pattern=ball is-live=true ! video/x-raw,format=I420,width=1280,height=720,framerate=25/1 \
+      gst_launch = "videotestsrc pattern=smpte is-live=true ! video/x-raw,format=I420,width=1280,height=720,framerate=25/1 \
                   ! identity name=post-src ! textoverlay text=\"System Breached!\" valignment=4 halignment=1 font-desc=Sans \
                   ! identity name=pre-x264enc ! queue ! x264enc tune=fastdecode bitrate=5000 speed-preset=superfast rc-lookahead=5 \
                   ! video/x-h264, stream-format=byte-stream, profile=baseline \


### PR DESCRIPTION
Changelog:
- Disable stopping & starting gstreamer node at the beginning of attack
- Optimize GST pipeline to handle frames and timestamps better
- Add video file playing functionality (passed with `-p video_file:=/home/sad/video_file.mp4`), if parameter is not set, the node will stream default videotestsrc.
- Change QoS of the videostreamcmd publisher.
- Signaling SIGINT when the end-of-stream reached with video playing